### PR TITLE
ValueError: Not the same graph

### DIFF
--- a/tf_agents/agents/dqn/examples/v1/train_eval_rnd.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_rnd.py
@@ -56,7 +56,7 @@ from tf_agents.utils import common
 
 flags.DEFINE_string('root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
                     'Root directory for writing logs/summaries/checkpoints.')
-flags.DEFINE_integer('num_iterations', 100000,
+flags.DEFINE_integer('num_iterations', 10000,
                      'Total number train/eval iterations to perform.')
 flags.DEFINE_bool('use_ddqn', False,
                   'If True uses the DdqnAgent instead of the DqnAgent.')

--- a/tf_agents/agents/dqn/examples/v1/train_eval_rnd.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_rnd.py
@@ -1,0 +1,306 @@
+# coding=utf-8
+# Copyright 2018 The TF-Agents Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Train and Eval DQN.
+
+To run:
+
+```bash
+tensorboard --logdir $HOME/tmp/rnddqn_v1/gym/CartPole-v0/ --port 2223 &
+
+python tf_agents/agents/dqn/examples/v1/train_eval_rnd.py \
+  --root_dir=$HOME/tmp/rnddqn_v1/gym/CartPole-v0/ \
+  --alsologtostderr
+```
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import time
+
+from absl import app
+from absl import flags
+from absl import logging
+
+import gin
+import tensorflow as tf
+
+from tf_agents.agents.dqn import dqn_agent
+from tf_agents.drivers import dynamic_step_driver
+from tf_agents.environments import suite_gym
+from tf_agents.environments import tf_py_environment
+from tf_agents.environments import rnd_wrapper
+from tf_agents.eval import metric_utils
+from tf_agents.metrics import py_metrics
+from tf_agents.metrics import tf_metrics
+from tf_agents.networks import q_network
+from tf_agents.policies import py_tf_policy
+from tf_agents.policies import random_tf_policy
+from tf_agents.replay_buffers import tf_uniform_replay_buffer
+from tf_agents.utils import common
+
+flags.DEFINE_string('root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
+                    'Root directory for writing logs/summaries/checkpoints.')
+flags.DEFINE_integer('num_iterations', 100000,
+                     'Total number train/eval iterations to perform.')
+flags.DEFINE_bool('use_ddqn', False,
+                  'If True uses the DdqnAgent instead of the DqnAgent.')
+FLAGS = flags.FLAGS
+
+
+@gin.configurable
+def train_eval(
+    root_dir,
+    env_name='CartPole-v0',
+    num_iterations=100000,
+    fc_layer_params=(100,),
+    # Params for collect
+    initial_collect_steps=1000,
+    collect_steps_per_iteration=1,
+    epsilon_greedy=0.1,
+    replay_buffer_capacity=100000,
+    # Params for target update
+    target_update_tau=0.05,
+    target_update_period=5,
+    # Params for train
+    train_steps_per_iteration=1,
+    batch_size=64,
+    learning_rate=1e-3,
+    gamma=0.99,
+    reward_scale_factor=1.0,
+    gradient_clipping=None,
+    # Params for eval
+    num_eval_episodes=10,
+    eval_interval=1000,
+    # Params for checkpoints, summaries, and logging
+    train_checkpoint_interval=10000,
+    policy_checkpoint_interval=5000,
+    rb_checkpoint_interval=20000,
+    log_interval=1000,
+    summary_interval=1000,
+    summaries_flush_secs=10,
+    agent_class=dqn_agent.DqnAgent,
+    debug_summaries=False,
+    summarize_grads_and_vars=False,
+    eval_metrics_callback=None):
+  """A simple train and eval for DQN."""
+  root_dir = os.path.expanduser(root_dir)
+  train_dir = os.path.join(root_dir, 'train')
+  eval_dir = os.path.join(root_dir, 'eval')
+
+  train_summary_writer = tf.compat.v2.summary.create_file_writer(
+      train_dir, flush_millis=summaries_flush_secs * 1000)
+  train_summary_writer.set_as_default()
+
+  eval_summary_writer = tf.compat.v2.summary.create_file_writer(
+      eval_dir, flush_millis=summaries_flush_secs * 1000)
+  eval_metrics = [
+      py_metrics.AverageReturnMetric(buffer_size=num_eval_episodes),
+      py_metrics.AverageEpisodeLengthMetric(buffer_size=num_eval_episodes),
+  ]
+
+  global_step = tf.compat.v1.train.get_or_create_global_step()
+  with tf.compat.v2.summary.record_if(
+      lambda: tf.math.equal(global_step % summary_interval, 0)):
+    tf_env = tf_py_environment.TFPyEnvironment(suite_gym.load(env_name, env_wrappers=[rnd_wrapper.RNDWrapper]))
+    eval_py_env = suite_gym.load(env_name)
+
+    q_net = q_network.QNetwork(
+        tf_env.time_step_spec().observation,
+        tf_env.action_spec(),
+        fc_layer_params=fc_layer_params)
+
+    # TODO(b/127301657): Decay epsilon based on global step, cf. cl/188907839
+    tf_agent = agent_class(
+        tf_env.time_step_spec(),
+        tf_env.action_spec(),
+        q_network=q_net,
+        optimizer=tf.compat.v1.train.AdamOptimizer(learning_rate=learning_rate),
+        epsilon_greedy=epsilon_greedy,
+        target_update_tau=target_update_tau,
+        target_update_period=target_update_period,
+        td_errors_loss_fn=dqn_agent.element_wise_squared_loss,
+        gamma=gamma,
+        reward_scale_factor=reward_scale_factor,
+        gradient_clipping=gradient_clipping,
+        debug_summaries=debug_summaries,
+        summarize_grads_and_vars=summarize_grads_and_vars,
+        train_step_counter=global_step)
+
+    replay_buffer = tf_uniform_replay_buffer.TFUniformReplayBuffer(
+        tf_agent.collect_data_spec,
+        batch_size=tf_env.batch_size,
+        max_length=replay_buffer_capacity)
+
+    eval_py_policy = py_tf_policy.PyTFPolicy(tf_agent.policy)
+
+    train_metrics = [
+        tf_metrics.NumberOfEpisodes(),
+        tf_metrics.EnvironmentSteps(),
+        tf_metrics.AverageReturnMetric(),
+        tf_metrics.AverageEpisodeLengthMetric(),
+    ]
+
+    replay_observer = [replay_buffer.add_batch]
+    initial_collect_policy = random_tf_policy.RandomTFPolicy(
+        tf_env.time_step_spec(), tf_env.action_spec())
+    initial_collect_op = dynamic_step_driver.DynamicStepDriver(
+        tf_env,
+        initial_collect_policy,
+        observers=replay_observer + train_metrics,
+        num_steps=initial_collect_steps).run()
+
+    collect_policy = tf_agent.collect_policy
+    collect_op = dynamic_step_driver.DynamicStepDriver(
+        tf_env,
+        collect_policy,
+        observers=replay_observer + train_metrics,
+        num_steps=collect_steps_per_iteration).run()
+
+    # Dataset generates trajectories with shape [Bx2x...]
+    dataset = replay_buffer.as_dataset(
+        num_parallel_calls=3,
+        sample_batch_size=batch_size,
+        num_steps=2).prefetch(3)
+
+    iterator = tf.compat.v1.data.make_initializable_iterator(dataset)
+    experience, _ = iterator.get_next()
+    train_op = common.function(tf_agent.train)(experience=experience)
+
+    train_checkpointer = common.Checkpointer(
+        ckpt_dir=train_dir,
+        agent=tf_agent,
+        global_step=global_step,
+        metrics=metric_utils.MetricsGroup(train_metrics, 'train_metrics'))
+    policy_checkpointer = common.Checkpointer(
+        ckpt_dir=os.path.join(train_dir, 'policy'),
+        policy=tf_agent.policy,
+        global_step=global_step)
+    rb_checkpointer = common.Checkpointer(
+        ckpt_dir=os.path.join(train_dir, 'replay_buffer'),
+        max_to_keep=1,
+        replay_buffer=replay_buffer)
+
+    summary_ops = []
+    for train_metric in train_metrics:
+      summary_ops.append(train_metric.tf_summaries(
+          train_step=global_step, step_metrics=train_metrics[:2]))
+
+    with eval_summary_writer.as_default(), \
+         tf.compat.v2.summary.record_if(True):
+      for eval_metric in eval_metrics:
+        eval_metric.tf_summaries(train_step=global_step)
+
+    init_agent_op = tf_agent.initialize()
+
+    with tf.compat.v1.Session() as sess:
+      # Initialize the graph.
+      train_checkpointer.initialize_or_restore(sess)
+      rb_checkpointer.initialize_or_restore(sess)
+      sess.run(iterator.initializer)
+      common.initialize_uninitialized_variables(sess)
+
+      sess.run(init_agent_op)
+      sess.run(train_summary_writer.init())
+      sess.run(eval_summary_writer.init())
+      sess.run(initial_collect_op)
+
+      global_step_val = sess.run(global_step)
+      metric_utils.compute_summaries(
+          eval_metrics,
+          eval_py_env,
+          eval_py_policy,
+          num_episodes=num_eval_episodes,
+          global_step=global_step_val,
+          callback=eval_metrics_callback,
+          log=True,
+      )
+
+      collect_call = sess.make_callable(collect_op)
+      global_step_call = sess.make_callable(global_step)
+      train_step_call = sess.make_callable([train_op, summary_ops])
+
+      timed_at_step = global_step_call()
+      collect_time = 0
+      train_time = 0
+      steps_per_second_ph = tf.compat.v1.placeholder(
+          tf.float32, shape=(), name='steps_per_sec_ph')
+      steps_per_second_summary = tf.compat.v2.summary.scalar(
+          name='global_steps_per_sec', data=steps_per_second_ph,
+          step=global_step)
+
+      for _ in range(num_iterations):
+        # Train/collect/eval.
+        start_time = time.time()
+        collect_call()
+        collect_time += time.time() - start_time
+        start_time = time.time()
+        for _ in range(train_steps_per_iteration):
+          loss_info_value, _ = train_step_call()
+        train_time += time.time() - start_time
+
+        global_step_val = global_step_call()
+
+        if global_step_val % log_interval == 0:
+          logging.info('step = %d, loss = %f', global_step_val,
+                       loss_info_value.loss)
+          steps_per_sec = (
+              (global_step_val - timed_at_step) / (collect_time + train_time))
+          sess.run(
+              steps_per_second_summary,
+              feed_dict={steps_per_second_ph: steps_per_sec})
+          logging.info('%.3f steps/sec', steps_per_sec)
+          logging.info('%s', 'collect_time = {}, train_time = {}'.format(
+              collect_time, train_time))
+          timed_at_step = global_step_val
+          collect_time = 0
+          train_time = 0
+
+        if global_step_val % train_checkpoint_interval == 0:
+          train_checkpointer.save(global_step=global_step_val)
+
+        if global_step_val % policy_checkpoint_interval == 0:
+          policy_checkpointer.save(global_step=global_step_val)
+
+        if global_step_val % rb_checkpoint_interval == 0:
+          rb_checkpointer.save(global_step=global_step_val)
+
+        if global_step_val % eval_interval == 0:
+          metric_utils.compute_summaries(
+              eval_metrics,
+              eval_py_env,
+              eval_py_policy,
+              num_episodes=num_eval_episodes,
+              global_step=global_step_val,
+              callback=eval_metrics_callback,
+          )
+
+
+def main(_):
+  logging.set_verbosity(logging.INFO)
+  tf.enable_resource_variables()
+  agent_class = dqn_agent.DdqnAgent if FLAGS.use_ddqn else dqn_agent.DqnAgent
+  train_eval(
+      FLAGS.root_dir,
+      agent_class=agent_class,
+      num_iterations=FLAGS.num_iterations)
+
+
+if __name__ == '__main__':
+  flags.mark_flag_as_required('root_dir')
+  app.run(main)

--- a/tf_agents/environments/rnd_wrapper.py
+++ b/tf_agents/environments/rnd_wrapper.py
@@ -40,6 +40,8 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
     super(RNDWrapper, self).__init__(env)
 
     # TODO Freeze rnd_target_net
+    print('[rnd_wrapper.py] self.time_step_spec().observation: ', self.time_step_spec().observation)
+    print('[rnd_wrapper.py] type(self.time_step_spec().observation): ', type(self.time_step_spec().observation))
     self.rnd_target_net = rnd_network.RNDNetwork(
         self.time_step_spec().observation,
         self.action_spec(),
@@ -71,15 +73,21 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
   def _get_intrinsic_reward(self, time_step):
     # TODO Implement
     # TODO Check type / dtype / shape
-    print(time_step)
+    print('[rnd_wrapper.py] time_step: ', time_step)
+    print('[rnd_wrapper.py] time_step.observation: ', time_step.observation)
+    print('[rnd_wrapper.py] type(time_step.observation): ', type(time_step.observation))
+    print('[rnd_wrapper.py] time_step.step_type: ', time_step.step_type)
+    print('[rnd_wrapper.py] type(time_step.step_type): ', type(time_step.step_type))
     # print('Observation Type: ', type(tf.convert_to_tensor(time_step.observation)))
     # print('Step type Type: ', type(tf.convert_to_tensor(time_step.step_type)))
     observation = tf.convert_to_tensor(time_step.observation)
     step_type = tf.convert_to_tensor(time_step.step_type)
     target_value, _ = self.rnd_target_net(observation,
                                           step_type)
+    print('[rnd_wrapper.py] target_value: ', target_value)
     predictor_value, _ = self.rnd_predictor_net(observation,
                                                 step_type)
+    print('[rnd_wrapper.py] predictor_value: ', predictor_value)
     # print('Target Value: ', target_value)
     # print('Predictor Value: ', predictor_value)
     return np.ones((), dtype=np.float32)

--- a/tf_agents/environments/rnd_wrapper.py
+++ b/tf_agents/environments/rnd_wrapper.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+# Copyright 2018 The TF-Agents Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper implementing Random Network Distillation (RND)."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import gym
+import gym.spaces
+import numpy as np
+import tensorflow as tf
+
+from tf_agents import specs
+from tf_agents.environments import wrappers
+from tf_agents.trajectories import time_step as ts
+from tensorflow.python.util import nest  # pylint:disable=g-direct-tensorflow-import  # TF internal
+
+
+@gin.configurable
+class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
+  def __init__(self, env):
+    super(RNDWrapper, self).__init__(env)
+
+    # TODO Initialize RND target network and RND predictor network
+
+  def _reset(self):
+    time_step = self._env.reset()
+    # TODO Compute intrinsic reward
+    intrinsic_reward = _get_intrinsic_reward(self, time_step.observation)
+    time_step._replace(reward=time_step.reward + intrinsic_reward)
+
+    return time_step
+
+  def _step(self, action):
+    time_step = self._env.step(action)
+    # TODO Compute intrinsic reward
+    intrinsic_reward = _get_intrinsic_reward(self, time_step.observation)
+    time_step._replace(reward=time_step.reward + intrinsic_reward)
+
+    return time_step
+  
+  def _get_intrinsic_reward(self, observation):
+    # TODO Implement
+    # TODO Check type / dtype / shape
+    return 0

--- a/tf_agents/environments/rnd_wrapper.py
+++ b/tf_agents/environments/rnd_wrapper.py
@@ -42,15 +42,37 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
     # TODO Freeze rnd_target_net
     print('[rnd_wrapper.py] self.time_step_spec().observation: ', self.time_step_spec().observation)
     print('[rnd_wrapper.py] type(self.time_step_spec().observation): ', type(self.time_step_spec().observation))
+
+    observation_spec = self.time_step_spec().observation
+    observation_spec = specs.BoundedTensorSpec(
+      observation_spec.shape,
+      observation_spec.dtype,
+      observation_spec.minimum,
+      observation_spec.maximum,
+      observation_spec.name,
+    )
+
+    action_spec = self.action_spec()
+    action_spec = specs.BoundedTensorSpec(
+      action_spec.shape,
+      action_spec.dtype,
+      action_spec.minimum,
+      action_spec.maximum,
+      action_spec.name,
+    )
+
+    print('[rnd_wrapper.py] observation_spec: ', observation_spec)
+    print('[rnd_wrapper.py] type(observation_spec): ', type(observation_spec))
+
     self.rnd_target_net = rnd_network.RNDNetwork(
-        self.time_step_spec().observation,
-        self.action_spec(),
+        observation_spec,
+        action_spec,
         fc_layer_params=(100, ),
     )
 
     self.rnd_predictor_net = rnd_network.RNDNetwork(
-        self.time_step_spec().observation,
-        self.action_spec(),
+        observation_spec,
+        action_spec,
         fc_layer_params=(100, ),
     )
 

--- a/tf_agents/environments/rnd_wrapper.py
+++ b/tf_agents/environments/rnd_wrapper.py
@@ -28,6 +28,7 @@ import tensorflow as tf
 
 from tf_agents import specs
 from tf_agents.environments import wrappers
+from tf_agents.networks import rnd_network
 from tf_agents.trajectories import time_step as ts
 from tensorflow.python.util import nest  # pylint:disable=g-direct-tensorflow-import  # TF internal
 
@@ -37,7 +38,18 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
   def __init__(self, env):
     super(RNDWrapper, self).__init__(env)
 
-    # TODO Initialize RND target network and RND predictor network
+    # TODO Freeze rnd_target_net
+    rnd_target_net = rnd_network.RNDNetwork(
+        self.time_step_spec().observation,
+        self.action_spec(),
+        fc_layer_params=(100, ),
+    )
+
+    rnd_predicctor_net = rnd_network.RNDNetwork(
+        self.time_step_spec().observation,
+        self.action_spec(),
+        fc_layer_params=(100, ),
+    )
 
   def _reset(self):
     time_step = self._env.reset()

--- a/tf_agents/environments/rnd_wrapper.py
+++ b/tf_agents/environments/rnd_wrapper.py
@@ -58,4 +58,4 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
   def _get_intrinsic_reward(self, observation):
     # TODO Implement
     # TODO Check type / dtype / shape
-    return 0
+    return np.ones((), dtype=np.float32)

--- a/tf_agents/environments/rnd_wrapper.py
+++ b/tf_agents/environments/rnd_wrapper.py
@@ -43,7 +43,7 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
     time_step = self._env.reset()
     # TODO Compute intrinsic reward
     intrinsic_reward = self._get_intrinsic_reward(time_step.observation)
-    time_step._replace(reward=time_step.reward + intrinsic_reward)
+    time_step = time_step._replace(reward=time_step.reward + intrinsic_reward)
 
     return time_step
 
@@ -51,7 +51,7 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
     time_step = self._env.step(action)
     # TODO Compute intrinsic reward
     intrinsic_reward = self._get_intrinsic_reward(time_step.observation)
-    time_step._replace(reward=time_step.reward + intrinsic_reward)
+    time_step = time_step._replace(reward=time_step.reward + intrinsic_reward)
 
     return time_step
   

--- a/tf_agents/environments/rnd_wrapper.py
+++ b/tf_agents/environments/rnd_wrapper.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import gin
 import gym
 import gym.spaces
 import numpy as np
@@ -41,7 +42,7 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
   def _reset(self):
     time_step = self._env.reset()
     # TODO Compute intrinsic reward
-    intrinsic_reward = _get_intrinsic_reward(self, time_step.observation)
+    intrinsic_reward = self._get_intrinsic_reward(time_step.observation)
     time_step._replace(reward=time_step.reward + intrinsic_reward)
 
     return time_step
@@ -49,7 +50,7 @@ class RNDWrapper(wrappers.PyEnvironmentBaseWrapper):
   def _step(self, action):
     time_step = self._env.step(action)
     # TODO Compute intrinsic reward
-    intrinsic_reward = _get_intrinsic_reward(self, time_step.observation)
+    intrinsic_reward = self._get_intrinsic_reward(time_step.observation)
     time_step._replace(reward=time_step.reward + intrinsic_reward)
 
     return time_step

--- a/tf_agents/networks/rnd_network.py
+++ b/tf_agents/networks/rnd_network.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+# Copyright 2018 The TF-Agents Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample Keras networks for DQN."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import gin
+import tensorflow as tf
+
+from tf_agents.networks import encoding_network
+from tf_agents.networks import network
+
+
+def validate_specs(action_spec, observation_spec):
+  """Validates the spec contains a single action."""
+  del observation_spec  # not currently validated
+
+  flat_action_spec = tf.nest.flatten(action_spec)
+  if len(flat_action_spec) > 1:
+    raise ValueError('Network only supports action_specs with a single action.')
+
+  if flat_action_spec[0].shape not in [(), (1,)]:
+    raise ValueError(
+        'Network only supports action_specs with shape in [(), (1,)])')
+
+
+@gin.configurable
+class RNDNetwork(network.Network):
+  """Feed Forward network."""
+
+  def __init__(self,
+               input_tensor_spec,
+               action_spec,
+               preprocessing_layers=None,
+               preprocessing_combiner=None,
+               conv_layer_params=None,
+               fc_layer_params=None,
+               dropout_layer_params=None,
+               activation_fn=tf.keras.activations.relu,
+               kernel_initializer=None,
+               batch_squash=True,
+               dtype=tf.float32,
+               name='RNDNetwork'):
+    """Creates an instance of `RNDNetwork`.
+
+    Args:
+      input_tensor_spec: A nest of `tensor_spec.TensorSpec` representing the
+        input observations.
+      action_spec: A nest of `tensor_spec.BoundedTensorSpec` representing the
+        actions.
+      preprocessing_layers: (Optional.) A nest of `tf.keras.layers.Layer`
+        representing preprocessing for the different observations.
+        All of these layers must not be already built. For more details see
+        the documentation of `networks.EncodingNetwork`.
+      preprocessing_combiner: (Optional.) A keras layer that takes a flat list
+        of tensors and combines them. Good options include
+        `tf.keras.layers.Add` and `tf.keras.layers.Concatenate(axis=-1)`.
+        This layer must not be already built. For more details see
+        the documentation of `networks.EncodingNetwork`.
+      conv_layer_params: Optional list of convolution layers parameters, where
+        each item is a length-three tuple indicating (filters, kernel_size,
+        stride).
+      fc_layer_params: Optional list of fully_connected parameters, where each
+        item is the number of units in the layer.
+      dropout_layer_params: Optional list of dropout layer parameters, where
+        each item is the fraction of input units to drop. The dropout layers are
+        interleaved with the fully connected layers; there is a dropout layer
+        after each fully connected layer, except if the entry in the list is
+        None. This list must have the same length of fc_layer_params, or be
+        None.
+      activation_fn: Activation function, e.g. tf.keras.activations.relu.
+      kernel_initializer: Initializer to use for the kernels of the conv and
+        dense layers. If none is provided a default variance_scaling_initializer
+      batch_squash: If True the outer_ranks of the observation are squashed into
+        the batch dimension. This allow encoding networks to be used with
+        observations with shape [BxTx...].
+      dtype: The dtype to use by the convolution and fully connected layers.
+      name: A string representing name of the network.
+
+    Raises:
+      ValueError: If `input_tensor_spec` contains more than one observation. Or
+        if `action_spec` contains more than one action.
+    """
+    validate_specs(action_spec, input_tensor_spec)
+    action_spec = tf.nest.flatten(action_spec)[0]
+    num_actions = action_spec.maximum - action_spec.minimum + 1
+
+    encoder = encoding_network.EncodingNetwork(
+        input_tensor_spec,
+        preprocessing_layers=preprocessing_layers,
+        preprocessing_combiner=preprocessing_combiner,
+        conv_layer_params=conv_layer_params,
+        fc_layer_params=fc_layer_params,
+        dropout_layer_params=dropout_layer_params,
+        activation_fn=activation_fn,
+        kernel_initializer=kernel_initializer,
+        batch_squash=batch_squash,
+        dtype=dtype)
+
+    super(RNDNetwork, self).__init__(
+        input_tensor_spec=input_tensor_spec,
+        state_spec=(),
+        name=name)
+
+    self._encoder = encoder
+
+  def call(self, observation, step_type=None, network_state=()):
+    # TODO What is network_state used for?
+    state, network_state = self._encoder(
+        observation, step_type=step_type, network_state=network_state)
+    return state, network_state

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -370,15 +370,15 @@ def get_outer_rank(tensors, specs):
   tensor_shapes = [t.shape for t in tf.nest.flatten(tensors)]
   spec_shapes = [s.shape for s in tf.nest.flatten(specs)]
   
-  print(specs)
-  print(specs.shape)
+  print('[nest_utils.py] specs: ', specs)
+  print('[nest_utils.py] specs.shape: ', specs.shape)
   for spec in tf.nest.flatten(specs):
-    print(spec)
-    print(spec.shape)
+    print('[nest_utils.py] spec: ', spec)
+    print('[nest_utils.py] spec.shape: ', spec.shape)
   for spec_shape in spec_shapes:
-    print(spec_shape)
-    print(type(spec_shape))
-  raise ValueError('What')
+    print('[nest_utils.py] spec_shape: ', spec_shape)
+    print('[nest_utils.py] type(spec_shape): ', type(spec_shape))
+  # raise ValueError('What')
 
   if any(spec_shape.ndims is None for spec_shape in spec_shapes):
     raise ValueError('All specs should have ndims defined.  Saw shapes: %s' %

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -369,6 +369,16 @@ def get_outer_rank(tensors, specs):
   tf.nest.assert_same_structure(tensors, specs)
   tensor_shapes = [t.shape for t in tf.nest.flatten(tensors)]
   spec_shapes = [s.shape for s in tf.nest.flatten(specs)]
+  
+  print(specs)
+  print(specs.shape)
+  for spec in tf.nest.flatten(specs):
+    print(spec)
+    print(spec.shape)
+  for spec_shape in spec_shapes:
+    print(spec_shape)
+    print(type(spec_shape))
+  raise ValueError('What')
 
   if any(spec_shape.ndims is None for spec_shape in spec_shapes):
     raise ValueError('All specs should have ndims defined.  Saw shapes: %s' %

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -370,14 +370,14 @@ def get_outer_rank(tensors, specs):
   tensor_shapes = [t.shape for t in tf.nest.flatten(tensors)]
   spec_shapes = [s.shape for s in tf.nest.flatten(specs)]
   
-  print('[nest_utils.py] specs: ', specs)
-  print('[nest_utils.py] specs.shape: ', specs.shape)
-  for spec in tf.nest.flatten(specs):
-    print('[nest_utils.py] spec: ', spec)
-    print('[nest_utils.py] spec.shape: ', spec.shape)
-  for spec_shape in spec_shapes:
-    print('[nest_utils.py] spec_shape: ', spec_shape)
-    print('[nest_utils.py] type(spec_shape): ', type(spec_shape))
+  # print('[nest_utils.py] specs: ', specs)
+  # print('[nest_utils.py] specs.shape: ', specs.shape)
+  # for spec in tf.nest.flatten(specs):
+  #   print('[nest_utils.py] spec: ', spec)
+  #   print('[nest_utils.py] spec.shape: ', spec.shape)
+  # for spec_shape in spec_shapes:
+  #   print('[nest_utils.py] spec_shape: ', spec_shape)
+  #   print('[nest_utils.py] type(spec_shape): ', type(spec_shape))
   # raise ValueError('What')
 
   if any(spec_shape.ndims is None for spec_shape in spec_shapes):


### PR DESCRIPTION
I successfully converted observation spec from `BoundedArraySpec` to `BoundedTensorSpec`! However, I get a ValueError when I try to run `train_eval_rnd.py`:

```
ValueError: Tensor("RNDNetwork/EncodingNetwork/EncodingNetwork/dense/kernel/Read/ReadVariableOp:0", 
shape=(4, 100), dtype=float32) must be from the same graph as 
Tensor("RNDNetwork/EncodingNetwork/flatten/Reshape:0", shape=(1, 4), dtype=float32).
```
(4 is the state dimension of CartPole, and 100 is the size of the fully connected layer.)

@oars @mandroid6 Do you have any suggestions on where I should pay attention to? I have been trying a few things but none of them fixed the issue. I am having trouble understanding why the tensors from the same network would be in different graphs.



Here is the full output: [output.txt](https://github.com/seungjaeryanlee/agents/files/3299278/output.txt)
